### PR TITLE
Fix redundant ProductImageTransfer external image properties override

### DIFF
--- a/tests/SprykerTest/Shared/ProductImage/_support/Helper/ProductImageDataHelper.php
+++ b/tests/SprykerTest/Shared/ProductImage/_support/Helper/ProductImageDataHelper.php
@@ -68,9 +68,6 @@ class ProductImageDataHelper extends Module
             ->seed($productImageOverride + $productImageSeed)
             ->build();
 
-        $productImageTransfer->setExternalUrlLarge(static::URL_SMALL)
-            ->setExternalUrlSmall(static::URL_LARGE);
-
         $productImageSetSeed = [
             ProductImageSetTransfer::NAME => static::NAME,
             ProductImageSetTransfer::LOCALE => $this->getLocaleFacade()->getCurrentLocale(),


### PR DESCRIPTION
Currently passing EXTERNAL_URL_SMALL or EXTERNAL_URL_LARGE in $productImageOverride has no effect, because these implicit setters are run after.

## PR Description

Noticed this issue while writing tests for the project that I'm working on. Currently, we're unable to create product images with different URLs because of this issue. 

Also, at the moment the properties that override the override are mixed up, causing even more confusion:  
```
        $productImageTransfer->setExternalUrlLarge(static::URL_SMALL)
            ->setExternalUrlSmall(static::URL_LARGE);
```

## Checklist
- [X] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
