### PR TITLE
Fixathon: Add image alt text

### DIFF
--- a/contribution-license-agreement.txt
+++ b/contribution-license-agreement.txt
@@ -1,0 +1,1 @@
+I hereby agree to Spryker's Contribution License Agreement in https://github.com/spryker/product-image/blob/7b929c0be80374b36bd81f0663ab8808fad18119/CONTRIBUTING.md

--- a/src/Spryker/Shared/ProductImage/Transfer/product_image.transfer.xml
+++ b/src/Spryker/Shared/ProductImage/Transfer/product_image.transfer.xml
@@ -17,7 +17,8 @@
         <property name="sortOrder" type="int"/>
         <property name="externalUrlSmall" type="string"/>
         <property name="externalUrlLarge" type="string"/>
-        <property name="altText" type="string"/>
+        <property name="altTextSmall" type="string"/>
+        <property name="altTextLarge" type="string"/>
     </transfer>
 
     <transfer name="ProductAbstract">

--- a/src/Spryker/Shared/ProductImage/Transfer/product_image.transfer.xml
+++ b/src/Spryker/Shared/ProductImage/Transfer/product_image.transfer.xml
@@ -17,6 +17,7 @@
         <property name="sortOrder" type="int"/>
         <property name="externalUrlSmall" type="string"/>
         <property name="externalUrlLarge" type="string"/>
+        <property name="altText" type="string"/>
     </transfer>
 
     <transfer name="ProductAbstract">

--- a/src/Spryker/Zed/ProductImage/Persistence/Propel/Schema/spy_product_image.schema.xml
+++ b/src/Spryker/Zed/ProductImage/Persistence/Propel/Schema/spy_product_image.schema.xml
@@ -41,7 +41,8 @@
         <column name="id_product_image" type="INTEGER" primaryKey="true" autoIncrement="true"/>
         <column name="external_url_small" type="VARCHAR" size="2048"/>
         <column name="external_url_large" type="VARCHAR" size="2048"/>
-        <column name="alt_text" type="VARCHAR" size="255" required="false"/>
+        <column name="alt_text_small" type="VARCHAR" size="255" required="false"/>
+        <column name="alt_text_large" type="VARCHAR" size="255" required="false"/>
 
         <behavior name="timestampable"/>
 

--- a/src/Spryker/Zed/ProductImage/Persistence/Propel/Schema/spy_product_image.schema.xml
+++ b/src/Spryker/Zed/ProductImage/Persistence/Propel/Schema/spy_product_image.schema.xml
@@ -41,6 +41,7 @@
         <column name="id_product_image" type="INTEGER" primaryKey="true" autoIncrement="true"/>
         <column name="external_url_small" type="VARCHAR" size="2048"/>
         <column name="external_url_large" type="VARCHAR" size="2048"/>
+        <column name="alt_text" type="VARCHAR" size="255" required="false"/>
 
         <behavior name="timestampable"/>
 

--- a/tests/SprykerTest/Shared/ProductImage/_support/Helper/ProductImageDataHelper.php
+++ b/tests/SprykerTest/Shared/ProductImage/_support/Helper/ProductImageDataHelper.php
@@ -49,6 +49,11 @@ class ProductImageDataHelper extends Module
     public const SORT_ORDER = 1;
 
     /**
+     * @var string
+     */
+    public const ALT_TEXT = 'alt text';
+
+    /**
      * @param array $productImageSetOverride
      * @param array $productImageOverride
      *
@@ -62,6 +67,7 @@ class ProductImageDataHelper extends Module
             ProductImageTransfer::EXTERNAL_URL_SMALL => static::URL_SMALL,
             ProductImageTransfer::EXTERNAL_URL_LARGE => static::URL_LARGE,
             ProductImageTransfer::SORT_ORDER => static::SORT_ORDER,
+            ProductImageTransfer::ALT_TEXT => static::ALT_TEXT,
         ];
 
         $productImageTransfer = (new ProductImageBuilder())
@@ -115,6 +121,7 @@ class ProductImageDataHelper extends Module
         $productImage
             ->setExternalUrlLarge(static::URL_LARGE)
             ->setExternalUrlSmall(static::URL_SMALL)
+            ->setAltText(static::ALT_TEXT)
             ->save();
 
         $productImageSetToProductImage = new SpyProductImageSetToProductImage();

--- a/tests/SprykerTest/Zed/ProductImage/Business/Facade/AbstractProductImageFacadeTest.php
+++ b/tests/SprykerTest/Zed/ProductImage/Business/Facade/AbstractProductImageFacadeTest.php
@@ -45,6 +45,16 @@ abstract class AbstractProductImageFacadeTest extends Unit
     /**
      * @var string
      */
+    protected const ALT_TEXT_SMALL = 'alt text small';
+
+    /**
+     * @var string
+     */
+    protected const ALT_TEXT_LARGE = 'alt text large';
+
+    /**
+     * @var string
+     */
     protected const SET_NAME = 'Default';
 
     /**
@@ -234,6 +244,8 @@ abstract class AbstractProductImageFacadeTest extends Unit
         $this->image
             ->setExternalUrlLarge(static::URL_LARGE)
             ->setExternalUrlSmall(static::URL_SMALL)
+            ->setAltTextSmall(static::ALT_TEXT_SMALL)
+            ->setAltTextLarge(static::ALT_TEXT_LARGE)
             ->save();
 
         $this->imageSetAbstract = new SpyProductImageSet();

--- a/tests/SprykerTest/Zed/ProductImage/Business/Facade/CreateProductAbstractImageSetCollectionTest.php
+++ b/tests/SprykerTest/Zed/ProductImage/Business/Facade/CreateProductAbstractImageSetCollectionTest.php
@@ -33,7 +33,9 @@ class CreateProductAbstractImageSetCollectionTest extends AbstractProductImageFa
 
         $productImageTransfer = (new ProductImageTransfer())
             ->setExternalUrlSmall(static::URL_SMALL)
-            ->setExternalUrlLarge(static::URL_LARGE);
+            ->setExternalUrlLarge(static::URL_LARGE)
+            ->setAltTextSmall(static::ALT_TEXT_SMALL)
+            ->setAltTextLarge(static::ALT_TEXT_LARGE);
 
         $productImageSetTransfer = (new ProductImageSetTransfer())
             ->setName(static::SET_NAME)

--- a/tests/SprykerTest/Zed/ProductImage/Business/Facade/CreateProductConcreteImageSetCollectionTest.php
+++ b/tests/SprykerTest/Zed/ProductImage/Business/Facade/CreateProductConcreteImageSetCollectionTest.php
@@ -33,7 +33,9 @@ class CreateProductConcreteImageSetCollectionTest extends AbstractProductImageFa
 
         $productImageTransfer = (new ProductImageTransfer())
             ->setExternalUrlSmall(static::URL_SMALL)
-            ->setExternalUrlLarge(static::URL_LARGE);
+            ->setExternalUrlLarge(static::URL_LARGE)
+            ->setAltTextSmall(static::ALT_TEXT_SMALL)
+            ->setAltTextLarge(static::ALT_TEXT_LARGE);
 
         $productImageSetTransfer = (new ProductImageSetTransfer())
             ->setName(static::SET_NAME)

--- a/tests/SprykerTest/Zed/ProductImage/Business/Facade/GetAbstractProductImageSetCollectionTest.php
+++ b/tests/SprykerTest/Zed/ProductImage/Business/Facade/GetAbstractProductImageSetCollectionTest.php
@@ -44,6 +44,16 @@ class GetAbstractProductImageSetCollectionTest extends Unit
     /**
      * @var string
      */
+    protected const FAKE_ALT_TEXT_SMALL = 'fake-alt-text-small';
+
+    /**
+     * @var string
+     */
+    protected const FAKE_ALT_TEXT_LARGE = 'fake-alt-text-large';
+
+    /**
+     * @var string
+     */
     protected const FAKE_NAME_FOO = 'foo';
 
     /**
@@ -229,6 +239,8 @@ class GetAbstractProductImageSetCollectionTest extends Unit
                 (new ProductImageBuilder())->seed([
                     ProductImageTransfer::EXTERNAL_URL_LARGE => static::FAKE_LARGE_URL,
                     ProductImageTransfer::EXTERNAL_URL_SMALL => static::FAKE_SMALL_URL,
+                    ProductImageTransfer::ALT_TEXT_SMALL => static::FAKE_ALT_TEXT_SMALL,
+                    ProductImageTransfer::ALT_TEXT_LARGE => static::FAKE_ALT_TEXT_LARGE,
                 ])->build(),
             ],
         ]);
@@ -249,6 +261,8 @@ class GetAbstractProductImageSetCollectionTest extends Unit
 
         $this->assertSame(static::FAKE_LARGE_URL, $productImageTransfer->getExternalUrlLarge());
         $this->assertSame(static::FAKE_SMALL_URL, $productImageTransfer->getExternalUrlSmall());
+        $this->assertSame(static::FAKE_ALT_TEXT_SMALL, $productImageTransfer->getAltTextSmall());
+        $this->assertSame(static::FAKE_ALT_TEXT_LARGE, $productImageTransfer->getAltTextLarge());
     }
 
     /**

--- a/tests/SprykerTest/Zed/ProductImage/Business/Facade/GetConcreteProductImageSetCollectionTest.php
+++ b/tests/SprykerTest/Zed/ProductImage/Business/Facade/GetConcreteProductImageSetCollectionTest.php
@@ -306,6 +306,8 @@ class GetConcreteProductImageSetCollectionTest extends AbstractProductImageFacad
                 (new ProductImageBuilder())->seed([
                     ProductImageTransfer::EXTERNAL_URL_LARGE => 'fake-large-url',
                     ProductImageTransfer::EXTERNAL_URL_SMALL => 'fake-small-url',
+                    ProductImageTransfer::ALT_TEXT_SMALL => 'fake-small-alt-text',
+                    ProductImageTransfer::ALT_TEXT_LARGE => 'fake-large-alt-text',
                 ])->build(),
             ],
         ]);
@@ -326,6 +328,8 @@ class GetConcreteProductImageSetCollectionTest extends AbstractProductImageFacad
 
         $this->assertSame('fake-large-url', $productImageTransfer->getExternalUrlLarge());
         $this->assertSame('fake-small-url', $productImageTransfer->getExternalUrlSmall());
+        $this->assertSame('fake-small-alt-text', $productImageTransfer->getAltTextSmall());
+        $this->assertSame('fake-large-alt-text', $productImageTransfer->getAltTextLarge());
     }
 
     /**
@@ -341,6 +345,8 @@ class GetConcreteProductImageSetCollectionTest extends AbstractProductImageFacad
                 (new ProductImageBuilder())->seed([
                     ProductImageTransfer::EXTERNAL_URL_LARGE => 'fake-large-url',
                     ProductImageTransfer::EXTERNAL_URL_SMALL => 'fake-small-url',
+                    ProductImageTransfer::ALT_TEXT_SMALL => 'fake-small-alt-text',
+                    ProductImageTransfer::ALT_TEXT_LARGE => 'fake-large-alt-text',
                 ])->build(),
             ],
         ]);

--- a/tests/SprykerTest/Zed/ProductImage/Business/Facade/SaveProductImageTest.php
+++ b/tests/SprykerTest/Zed/ProductImage/Business/Facade/SaveProductImageTest.php
@@ -31,7 +31,9 @@ class SaveProductImageTest extends AbstractProductImageFacadeTest
         // Arrange
         $productImageTransfer = (new ProductImageTransfer())
             ->setExternalUrlSmall(static::URL_SMALL)
-            ->setExternalUrlLarge(static::URL_LARGE);
+            ->setExternalUrlLarge(static::URL_LARGE)
+            ->setAltTextSmall(static::ALT_TEXT_SMALL)
+            ->setAltTextLarge(static::ALT_TEXT_LARGE);
 
         // Act
         $productImageTransfer = $this->productImageFacade->saveProductImage($productImageTransfer);

--- a/tests/SprykerTest/Zed/ProductImage/Business/Facade/UpdateProductAbstractImageSetCollectionTest.php
+++ b/tests/SprykerTest/Zed/ProductImage/Business/Facade/UpdateProductAbstractImageSetCollectionTest.php
@@ -35,7 +35,9 @@ class UpdateProductAbstractImageSetCollectionTest extends AbstractProductImageFa
         $productImageTransfer = (new ProductImageTransfer())
             ->setIdProductImage($this->image->getIdProductImage())
             ->setExternalUrlSmall(static::URL_SMALL . 'foo')
-            ->setExternalUrlLarge(static::URL_LARGE . 'foo');
+            ->setExternalUrlLarge(static::URL_LARGE . 'foo')
+            ->setAltTextSmall(static::ALT_TEXT_SMALL . 'foo')
+            ->setAltTextLarge(static::ALT_TEXT_LARGE . 'foo');
 
         $productImageSetTransfer = (new ProductImageSetTransfer())
             ->setIdProductImageSet($this->imageSetAbstract->getIdProductImageSet())
@@ -67,7 +69,9 @@ class UpdateProductAbstractImageSetCollectionTest extends AbstractProductImageFa
 
         $productImageTransfer = (new ProductImageTransfer())
             ->setExternalUrlSmall(static::URL_SMALL)
-            ->setExternalUrlLarge(static::URL_LARGE);
+            ->setExternalUrlLarge(static::URL_LARGE)
+            ->setAltTextSmall(static::ALT_TEXT_SMALL)
+            ->setAltTextLarge(static::ALT_TEXT_LARGE);
 
         $productImageSetTransfer = (new ProductImageSetTransfer())
             ->setName(static::SET_NAME)
@@ -101,7 +105,9 @@ class UpdateProductAbstractImageSetCollectionTest extends AbstractProductImageFa
 
         $productImageTransfer = (new ProductImageTransfer())
             ->setExternalUrlSmall(static::URL_SMALL)
-            ->setExternalUrlLarge(static::URL_LARGE);
+            ->setExternalUrlLarge(static::URL_LARGE)
+            ->setAltTextSmall(static::ALT_TEXT_SMALL)
+            ->setAltTextLarge(static::ALT_TEXT_LARGE);
 
         $productImageSetTransfer = (new ProductImageSetTransfer())
             ->setName(static::SET_NAME)

--- a/tests/SprykerTest/Zed/ProductImage/Business/Facade/UpdateProductConcreteImageSetCollectionTest.php
+++ b/tests/SprykerTest/Zed/ProductImage/Business/Facade/UpdateProductConcreteImageSetCollectionTest.php
@@ -34,7 +34,9 @@ class UpdateProductConcreteImageSetCollectionTest extends AbstractProductImageFa
         $productImageTransfer = (new ProductImageTransfer())
             ->setIdProductImage($this->image->getIdProductImage())
             ->setExternalUrlSmall(static::URL_SMALL)
-            ->setExternalUrlLarge(static::URL_LARGE);
+            ->setExternalUrlLarge(static::URL_LARGE)
+            ->setAltTextSmall(static::ALT_TEXT_SMALL)
+            ->setAltTextLarge(static::ALT_TEXT_LARGE);
 
         $productImageSetTransfer = (new ProductImageSetTransfer())
             ->setIdProductImageSet($this->imageSetConcrete->getIdProductImageSet())
@@ -63,7 +65,9 @@ class UpdateProductConcreteImageSetCollectionTest extends AbstractProductImageFa
 
         $productImageTransfer = (new ProductImageTransfer())
             ->setExternalUrlSmall(static::URL_SMALL)
-            ->setExternalUrlLarge(static::URL_LARGE);
+            ->setExternalUrlLarge(static::URL_LARGE)
+            ->setAltTextSmall(static::ALT_TEXT_SMALL)
+            ->setAltTextLarge(static::ALT_TEXT_LARGE);
 
         $productImageSetTransfer = (new ProductImageSetTransfer())
             ->setName(static::SET_NAME)
@@ -95,7 +99,9 @@ class UpdateProductConcreteImageSetCollectionTest extends AbstractProductImageFa
 
         $productImageTransfer = (new ProductImageTransfer())
             ->setExternalUrlSmall(static::URL_SMALL)
-            ->setExternalUrlLarge(static::URL_LARGE);
+            ->setExternalUrlLarge(static::URL_LARGE)
+            ->setAltTextSmall(static::ALT_TEXT_SMALL)
+            ->setAltTextLarge(static::ALT_TEXT_LARGE);
 
         $productImageSetTransfer = (new ProductImageSetTransfer())
             ->setName(static::SET_NAME)

--- a/tests/SprykerTest/Zed/ProductImage/Business/Model/ProductImageWriterTest.php
+++ b/tests/SprykerTest/Zed/ProductImage/Business/Model/ProductImageWriterTest.php
@@ -75,7 +75,9 @@ class ProductImageWriterTest extends Unit
         $imageTransfer
             ->setSortOrder(11)
             ->setExternalUrlLarge('large')
-            ->setExternalUrlSmall('small');
+            ->setExternalUrlSmall('small')
+            ->setAltTextSmall('alt text small')
+            ->setAltTextLarge('alt text large');
 
         $imageTransfer = $this->writer
             ->saveProductImage($imageTransfer);
@@ -95,7 +97,9 @@ class ProductImageWriterTest extends Unit
         $imageTransfer
             ->setSortOrder(7)
             ->setExternalUrlLarge('large')
-            ->setExternalUrlSmall('small');
+            ->setExternalUrlSmall('small')
+            ->setAltTextSmall('alt text small')
+            ->setAltTextLarge('alt text large');
 
         $imageCollection = new ArrayObject([$imageTransfer]);
 

--- a/tests/_data/product_image.databuilder.xml
+++ b/tests/_data/product_image.databuilder.xml
@@ -13,6 +13,8 @@
         <property name="sortOrder" dataBuilderRule="randomDigit()"/>
         <property name="externalUrlSmall" dataBuilderRule="imageUrl(640, 480)"/>
         <property name="externalUrlLarge" dataBuilderRule="imageUrl(640, 480)"/>
+        <property name="altTextSmall" dataBuilderRule="text(100)"/>
+        <property name="altTextLarge" dataBuilderRule="text(200)"/>
     </transfer>
 
 </transfers>


### PR DESCRIPTION
## PR Description
This PR and all included in Core PRs enable Spryker users to set HTML alt text for product images in small and large version.

## Steps before you submit a PR
- Please add tests for the code you add if it's possible.
- Please check out our contribution guide: https://docs.spryker.com/docs/dg/dev/code-contribution-guide.html
- Add a `contribution-license-agreement.txt` file with the following content:
`I hereby agree to Spryker\'s Contribution License Agreement in https://github.com/spryker/product-image/blob/HASH_OF_COMMIT_YOU_ARE_BASING_YOUR_BRANCH_FROM_MASTER_BRANCH/CONTRIBUTING.md.`

This is a mandatory step to make sure you are aware of the license agreement and agree to it. `HASH_OF_COMMIT_YOU_ARE_BASING_YOUR_BRANCH_FROM_MASTER_BRANCH` is a hash of the commit you are basing your branch from the master branch. You can take it from commits list of master branch before you submit a PR.

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
